### PR TITLE
Add additional use cases to README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,20 @@ It accepts 2 values:
 
 Both values take an array of strings, as in the example just above.
 
+If no keywords or ranges are specified, or if none are present in the given search query, then `searchQuery.parse` will return a string.
+
+```javascript
+var searchQuery = require('search-query-parser');
+
+var query = 'a query with just text';
+var parsedQuery = searchQuery.parse(query);
+// parsedQuery is now 'a query with just text'
+
+var options = {keywords: ['unused']};
+var parsedQueryWithOptions = searchQuery.parse(query, options);
+// parsedQueryWithOptions is now 'a query with just text'
+```
+
 ## Testing
 
 The 17 tests are written using the BDD testing framework should.js, and run with mocha.


### PR DESCRIPTION
As I mentioned in issue #3 , I thought it could be clearer how the parser will behave when no keywords are present in the query. This PR adds those cases to the README.