### PR TITLE
set an empty string when string was not provided

### DIFF
--- a/lib/search-query-parser.js
+++ b/lib/search-query-parser.js
@@ -11,6 +11,10 @@ exports.parse = function (string, options) {
     options = {};
   }
 
+  if (!string) {
+    string = '';
+  }
+
   // Regularize white spacing
   // Make in-between white spaces a unique space
   string = string.trim().replace(/\s+/g, ' ');


### PR DESCRIPTION
preventing TypeError: Cannot read property 'trim' of undefined or TypeError: Cannot read property 'trim' of null