### PR TITLE
types: make parse function more specific

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,4 +29,10 @@ export interface SearchParserResult extends ISearchParserDictionary {
   exclude?: ISearchParserDictionary;
 }
 
+export function parse(string: string, options?: SearchParserOptions & {
+  tokenize: false
+}): string;
+export function parse(string: string, options?: SearchParserOptions & {
+  tokenize: true
+}): SearchParserResult;
 export function parse(string: string, options?: SearchParserOptions): string | SearchParserResult;

--- a/index.d.ts
+++ b/index.d.ts
@@ -35,6 +35,6 @@ export function parse(string: string, options?: SearchParserOptions & {
 export function parse(string: string, options?: SearchParserOptions & {
   tokenize: true
 }): SearchParserResult & {
-  text: string[]
+  text?: string[]
 };
 export function parse(string: string, options?: SearchParserOptions): string | SearchParserResult;

--- a/index.d.ts
+++ b/index.d.ts
@@ -34,5 +34,7 @@ export function parse(string: string, options?: SearchParserOptions & {
 }): string;
 export function parse(string: string, options?: SearchParserOptions & {
   tokenize: true
-}): SearchParserResult;
+}): SearchParserResult & {
+  text: string[]
+};
 export function parse(string: string, options?: SearchParserOptions): string | SearchParserResult;


### PR DESCRIPTION
This will make the parse function more specific and return the proper return type depending on "tokenize".