### PR TITLE
feat: add stringify function

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ var searchQueryObj = searchQuery.parse(query, options);
 searchQueryObj.to = 'you';
 var newQuery = searchQuery.stringify(query, options);
 
-// newQuery is now: photos from:hi@retrace.io,foo@gmail.com __to:you__ subject:vacations date:1/10/2013-15/04/2014
+// newQuery is now: photos from:hi@retrace.io,foo@gmail.com to:you subject:vacations date:1/10/2013-15/04/2014
 ```
 
 ## Typescript

--- a/README.md
+++ b/README.md
@@ -112,7 +112,23 @@ var parsedQueryWithOptions = searchQuery.parse(query, options);
 // }
 ```
 
-The offsets object could become pretty huge with long search queries which could be an unnecessary use of space if no functionality depends on it. It can simply be turned off using the option `offsets: false`
+The offsets object could become pretty huge with long search queries which could be an unnecessary use of space if no functionality depends on it. It can simply be turned off using the option `offsets: false`.
+
+Anytime, you can go back and stringify the parsed search query. This could be handy if you would like to manipulate the parsed search query object.
+
+```javascript
+var searchQuery = require('search-query-parser');
+
+var query = 'from:hi@retrace.io,foo@gmail.com to:me subject:vacations date:1/10/2013-15/04/2014 photos';
+var options = {keywords: ['from', 'to', 'subject'], ranges: ['date']}
+
+var searchQueryObj = searchQuery.parse(query, options);
+
+searchQueryObj.to = 'you';
+var newQuery = searchQuery.stringify(query, options);
+
+// newQuery is now: photos from:hi@retrace.io,foo@gmail.com __to:you__ subject:vacations date:1/10/2013-15/04/2014
+```
 
 ## Typescript
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -30,3 +30,5 @@ export interface SearchParserResult extends ISearchParserDictionary {
 }
 
 export function parse(string: string, options?: SearchParserOptions): string | SearchParserResult;
+
+export function stringify(searchParserResult: string | SearchParserResult, options?: SearchParserOptions): string;

--- a/lib/search-query-parser.js
+++ b/lib/search-query-parser.js
@@ -309,3 +309,103 @@ exports.parse = function (string, options) {
   }
 
 };
+
+exports.stringify = function (queryObject, options, prefix) {
+  // If the query object is falsy we can just return an empty string
+  if (!queryObject) {
+    return '';
+  }
+
+  // If the query object is already a string, we can return it immediately
+  if (typeof queryObject === 'string') {
+    return queryObject;
+  }
+
+  // If the query object does not have any keys, we can return an empty string
+  if (!Object.keys(queryObject).length) {
+    return '';
+  }
+
+  // If the query object contains only text which is a string, we can return it immediately
+  if (Object.keys(queryObject).length === 3 && !!queryObject.text && !!queryObject.offsets && !!queryObject.exclude && typeof queryObject.text === 'string') {
+    return queryObject.text;
+  }
+
+  // We will use prefix for the exclude syntax later one
+  if (!prefix) {
+    prefix = ''
+  }
+
+  // Helpers
+  var addQuotes = function (string) {
+    return string.indexOf(' ') > - 1 ? JSON.stringify(string) : string;
+  };
+  var addPrefix = function (string) {
+    return prefix + string;
+  };
+
+  // Keep track of all single parts in this array
+  var parts = [];
+
+  // Text
+  if (queryObject.text) {
+    var value = [];
+    if (typeof queryObject.text === 'string') {
+      value.push(queryObject.text);
+    } else {
+      value.push.apply(value, queryObject.text);
+    }
+
+    if (value.length > 0) {
+      parts.push(value.map(addQuotes).map(addPrefix).join(' '));
+    }
+  }
+
+  // Keywords
+  if (options.keywords) {
+    options.keywords.forEach(function (keyword) {
+      if (!queryObject[keyword]) {
+        return
+      }
+
+      var value = [];
+      if (typeof queryObject[keyword] === 'string') {
+        value.push(queryObject[keyword]);
+      } else {
+        value.push.apply(value, queryObject[keyword]);
+      }
+
+      if (value.length > 0) {
+        parts.push(addPrefix(keyword + ':' + value.map(addQuotes).join(',')));
+      }
+    });
+  }
+
+  // Ranges
+  if (options.ranges) {
+    options.ranges.forEach(function (range) {
+      if (!queryObject[range]) {
+        return
+      }
+
+      var value = queryObject[range].from;
+      var to = queryObject[range].to;
+      if (to) {
+        value = value + '-' + to;
+      }
+
+      if (value) {
+        parts.push(addPrefix(range + ':' + value));
+      }
+    });
+  }
+
+  // Exclude
+  if (queryObject.exclude) {
+    if (Object.keys(queryObject.exclude).length > 0) {
+      parts.push(exports.stringify(queryObject.exclude, options, '-'));
+    }
+  }
+
+  return parts.join(' ');
+};

--- a/lib/search-query-parser.js
+++ b/lib/search-query-parser.js
@@ -311,6 +311,12 @@ exports.parse = function (string, options) {
 };
 
 exports.stringify = function (queryObject, options, prefix) {
+
+  // Set a default options object when none is provided
+  if (!options) {
+    options = {offsets: true};
+  }
+
   // If the query object is falsy we can just return an empty string
   if (!queryObject) {
     return '';
@@ -319,6 +325,11 @@ exports.stringify = function (queryObject, options, prefix) {
   // If the query object is already a string, we can return it immediately
   if (typeof queryObject === 'string') {
     return queryObject;
+  }
+
+  // If the query object is an array, we can return it concatenated with a space
+  if (Array.isArray(queryObject)) {
+    return queryObject.join(' ');
   }
 
   // If the query object does not have any keys, we can return an empty string
@@ -331,7 +342,7 @@ exports.stringify = function (queryObject, options, prefix) {
     return queryObject.text;
   }
 
-  // We will use prefix for the exclude syntax later one
+  // We will use a prefix for the exclude syntax later one
   if (!prefix) {
     prefix = ''
   }
@@ -408,4 +419,5 @@ exports.stringify = function (queryObject, options, prefix) {
   }
 
   return parts.join(' ');
+
 };

--- a/test/test.js
+++ b/test/test.js
@@ -12,7 +12,10 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.a.string;
     parsedSearchQuery.should.equal(searchQuery);
-
+    var a= searchquery.parse('from:hi@retrace.io,foo@gmail.com to:me subject:vacations date:1/10/2013-15/04/2014 photos', {keywords: ['from', 'to', 'subject'], ranges: ['date']})
+    console.log(a)
+    a.to = 'you'
+console.log(searchquery.stringify(a, {keywords: ['from', 'to', 'subject'], ranges: ['date']}))
     var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery));
     parsedAfterStringifySearchQuery.should.be.equal(parsedSearchQuery);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -12,10 +12,6 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.a.string;
     parsedSearchQuery.should.equal(searchQuery);
-    var a= searchquery.parse('from:hi@retrace.io,foo@gmail.com to:me subject:vacations date:1/10/2013-15/04/2014 photos', {keywords: ['from', 'to', 'subject'], ranges: ['date']})
-    console.log(a)
-    a.to = 'you'
-console.log(searchquery.stringify(a, {keywords: ['from', 'to', 'subject'], ranges: ['date']}))
     var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery));
     parsedAfterStringifySearchQuery.should.be.equal(parsedSearchQuery);
   });

--- a/test/test.js
+++ b/test/test.js
@@ -12,6 +12,9 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.a.string;
     parsedSearchQuery.should.equal(searchQuery);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery));
+    parsedAfterStringifySearchQuery.should.be.equal(parsedSearchQuery);
   });
 
   it('should return a tokenized string when option is set', function () {
@@ -21,6 +24,11 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', ['fancy', 'pyjama', 'wear']);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should return a tokenized string when option is set, respecting double-quotes and escapes', function () {
@@ -30,6 +38,11 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', ['fancy', 'py"j"am\'a w\'ear']);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should return a tokenized string when option is set, respecting single-quotes and escapes', function () {
@@ -39,6 +52,11 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', ['fancy', "py'j'am\"a w\"ear"]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should return a tokenized string with negation of unquoted terms', function () {
@@ -49,6 +67,11 @@ describe('Search query syntax parser', function () {
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', ['fancy']);
     parsedSearchQuery.should.have.property('exclude', {text: ['pyjama', 'wear']});
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should return a tokenized string with negation of single-quoted terms', function () {
@@ -59,6 +82,11 @@ describe('Search query syntax parser', function () {
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', ['fancy']);
     parsedSearchQuery.should.have.property('exclude', {text: 'pyjama -wear'});
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should return a tokenized string with negation of double-quoted terms', function () {
@@ -69,6 +97,11 @@ describe('Search query syntax parser', function () {
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', ['fancy']);
     parsedSearchQuery.should.have.property('exclude', {text: 'pyjama -wear'});
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should parse a single keyword with no text', function () {
@@ -85,6 +118,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 0,
       offsetEnd: 16
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -110,6 +148,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 21,
       offsetEnd: 27
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -136,6 +179,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 13,
       offsetEnd: 30
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -161,6 +209,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 9,
       offsetEnd: 25
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -190,6 +243,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 26,
       offsetEnd: 31
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -220,6 +278,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 35,
       offsetEnd: 40
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -263,6 +326,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 49,
       offsetEnd: 54
     }]);
+    
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -293,6 +361,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 33,
       offsetEnd: 47
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -313,6 +386,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 0,
       offsetEnd: 27
     }]);
+    
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -345,6 +423,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 45,
       offsetEnd: 51
     }]);
+    
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should always return an array if alwaysArray is set to true', function () {
@@ -386,6 +469,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 42,
       offsetEnd: 48
     }]);
+    
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should parse range with only 1 end and free text', function () {
@@ -408,6 +496,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 16,
       offsetEnd: 21
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should parse range with 2 ends and free text', function () {
@@ -431,6 +524,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 27,
       offsetEnd: 32
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -440,6 +538,11 @@ describe('Search query syntax parser', function () {
 
     parsedSearchQuery.should.be.a.string;
     parsedSearchQuery.should.be.equal('✓ about 这个事儿');
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery));
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -451,6 +554,11 @@ describe('Search query syntax parser', function () {
     parsedSearchQuery.should.be.an.Object;
     parsedSearchQuery.should.have.property('text', '✓ about 这个事儿');
     parsedSearchQuery.should.have.property('from', 'dr@who.co.uk');
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -519,6 +627,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 124,
       offsetEnd: 128
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -541,6 +654,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 17,
       offsetEnd: 47
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -563,6 +681,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 29,
       offsetEnd: 57
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
 
@@ -581,6 +704,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 1,
       offsetEnd: 17
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should concatenate a keyword multiple values in exclusion syntax', function() {
@@ -599,6 +727,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 1,
       offsetEnd: 29
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should support keywords which appear multiple times with exclusion syntax', function() {
@@ -625,6 +758,11 @@ describe('Search query syntax parser', function () {
       offsetStart: 31,
       offsetEnd: 47
     }]);
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 
   it('should not return offset when offsets option is set to false', function() {
@@ -645,5 +783,10 @@ describe('Search query syntax parser', function () {
     parsedSearchQuery.should.have.property('date');
     parsedSearchQuery.date.from.should.containEql('12/12/2012');
     parsedSearchQuery.should.not.have.property('offsets');
+
+    var parsedAfterStringifySearchQuery = searchquery.parse(searchquery.stringify(parsedSearchQuery, options), options);
+    parsedAfterStringifySearchQuery.offsets = undefined;
+    parsedSearchQuery.offsets = undefined;
+    parsedAfterStringifySearchQuery.should.be.eql(parsedSearchQuery);
   });
 });


### PR DESCRIPTION
This PR will add a stringify function which can convert a parsed search query object to a string. I added a part to every test where the parsed search query is stringified and parsed again. If the object equals the previous parsed object (except for the offsets) we can consider it as successful.